### PR TITLE
💡 フィルターのパターンを制限

### DIFF
--- a/src/main/kotlin/com/knarusawa/idp/configuration/WebConfig.kt
+++ b/src/main/kotlin/com/knarusawa/idp/configuration/WebConfig.kt
@@ -7,6 +7,7 @@ import org.springframework.security.authentication.AuthenticationEventPublisher
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
+
 @Configuration
 class WebConfig : WebMvcConfigurer {
   @Bean

--- a/src/main/kotlin/com/knarusawa/idp/infrastructure/filter/RequestFilter.kt
+++ b/src/main/kotlin/com/knarusawa/idp/infrastructure/filter/RequestFilter.kt
@@ -9,6 +9,14 @@ import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
 class RequestFilter : OncePerRequestFilter() {
+  companion object {
+    val excludeUrlRegexList = listOf(
+      Regex(".*webjars.*"),
+      Regex(".*csv.*"),
+      Regex(".*\\.png"),
+    )
+  }
+
   override fun doFilterInternal(
     request: HttpServletRequest,
     response: HttpServletResponse,
@@ -22,5 +30,10 @@ class RequestFilter : OncePerRequestFilter() {
       val end = System.currentTimeMillis()
       logger.info("METHOD: ${request.method}, REQUEST_URL: ${request.requestURI}, RESPONSE_TIME: ${end - start}ms")
     }
+  }
+
+  override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+    val path = request.requestURI
+    return excludeUrlRegexList.any { path.matches(it) }
   }
 }


### PR DESCRIPTION
リクエストフィルターのノイズが大きいので静的ファイルのリクエストを除外